### PR TITLE
Call finish() on query object

### DIFF
--- a/lib/DBD/Neo4p.pm
+++ b/lib/DBD/Neo4p.pm
@@ -451,6 +451,8 @@ sub rows ($) {
 
 sub finish ($) {
   my ($sth) = @_;
+  $sth->{"${prefix}_query_obj"}->finish()
+    if (defined($sth->{"${prefix}_query_obj"}));
   $sth->{"${prefix}_query_obj"} = undef;
   $sth->STORE(Active => 0);
   $sth->SUPER::finish();


### PR DESCRIPTION
This is to force the cleanup of the temporary file and to prevent a too
many files open error.
